### PR TITLE
Handle failing promises in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,10 @@ $ npm i h2url
 ```js
 'use strict'
 
-const { to } = require('await-to-ts')
-const { ifError } = require('assert')
-const getStream = require('get-stream')
+require('make-promises-safe')
 const h2url = require('h2url')
-
 const url = 'https://localhost:3001'
+const getStream = require('get-stream')
 
 async function concat () {
   const res = await h2url.concat({ url })
@@ -50,25 +48,23 @@ async function concat () {
   // prints { headers, body }
 }
 
-concat().catch(console.error.bind(console))
+concat()
 
 async function streaming () {
-  const [err, res] = await to(h2url.request({
+  const res = await h2url.request({
     method: 'POST',
     headers: {
       'content-type': 'application/json'
     },
     body: JSON.stringify('something') // string, buffer or readable stream
-  }))
+  })
 
-  ifError(err)
   console.log(res.headers)
   const body = getStream(res.stream)
   console.log(body)
 }
 
-streaming().catch(console.error.bind(console))
-
+streaming()
 ```
 
 ## License

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,48 +1,12 @@
-# h2url
-
-Experimental http2 client for node and the CLI
-
-## Usage as CLI
-
-```
-$ npx h2url https://localhost:3001
-```
-
-or
-
-```
-$ npm i -g h2url
-$ h2url https://localhost:3001
-```
-
-### CLI options
-
-```
-Usage: h2url [options..] URL
-
-Options:
-
-  -X/--method METHOD      the http method to use
-  -D/--data/--body BODY   the http body to send
-  -v/--verbose            show the headers
-  -h                      show this help
-```
-
-## Usage as a module
-
-```
-$ npm i h2url
-```
-
-```js
 'use strict'
 
 const { to } = require('await-to-ts')
 const { ifError } = require('assert')
 const getStream = require('get-stream')
-const h2url = require('h2url')
 
-const url = 'https://localhost:3001'
+const h2url = require('.')
+
+const url = 'https://www.google.com'
 
 async function concat () {
   const res = await h2url.concat({ url })
@@ -68,9 +32,3 @@ async function streaming () {
 }
 
 streaming().catch(console.error.bind(console))
-
-```
-
-## License
-
-MIT

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,35 +1,31 @@
 'use strict'
 
-const { to } = require('await-to-ts')
-const { ifError } = require('assert')
+require('make-promises-safe')
+const h2url = require('..')
 const getStream = require('get-stream')
 
-const h2url = require('.')
-
-const url = 'https://www.google.com'
+const url = 'https://google.com'
 
 async function concat () {
-  const [err, res] = await to(h2url.concat({ url }))
-  ifError(err)
+  const res = await h2url.concat({ url })
   console.log(res)
   // prints { headers, body }
 }
 
-concat().catch(console.error.bind(console))
+concat()
 
 async function streaming () {
-  const [err, res] = await to(h2url.request({
-    method: 'POST',
+  const res = await h2url.request({
+    method: 'GET',
     headers: {
-      'content-type': 'application/json'
-    },
-    body: JSON.stringify('something') // string, buffer or readable stream
-  }))
+      // 'content-type': 'application/json'
+    }// ,
+    // body: JSON.stringify('something') // string, buffer or readable stream
+  })
 
-  ifError(err)
   console.log(res.headers)
   const body = getStream(res.stream)
   console.log(body)
 }
 
-streaming().catch(console.error.bind(console))
+streaming()

--- a/examples/example.js
+++ b/examples/example.js
@@ -9,7 +9,8 @@ const h2url = require('.')
 const url = 'https://www.google.com'
 
 async function concat () {
-  const res = await h2url.concat({ url })
+  const [err, res] = await to(h2url.concat({ url }))
+  ifError(err)
   console.log(res)
   // prints { headers, body }
 }

--- a/examples/example.js
+++ b/examples/example.js
@@ -2,7 +2,6 @@
 
 require('make-promises-safe')
 const h2url = require('..')
-const getStream = require('get-stream')
 
 const url = 'https://google.com'
 
@@ -13,19 +12,3 @@ async function concat () {
 }
 
 concat()
-
-async function streaming () {
-  const res = await h2url.request({
-    method: 'GET',
-    headers: {
-      // 'content-type': 'application/json'
-    }// ,
-    // body: JSON.stringify('something') // string, buffer or readable stream
-  })
-
-  console.log(res.headers)
-  const body = getStream(res.stream)
-  console.log(body)
-}
-
-streaming()

--- a/examples/example.localhost.js
+++ b/examples/example.localhost.js
@@ -1,0 +1,31 @@
+'use strict'
+
+require('make-promises-safe')
+const h2url = require('..')
+const getStream = require('get-stream')
+
+const url = 'https://localhost:3001'
+
+async function concat () {
+  const res = await h2url.concat({ url })
+  console.log(res)
+  // prints { headers, body }
+}
+
+concat()
+
+async function streaming () {
+  const res = await h2url.request({
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify('something') // string, buffer or readable stream
+  })
+
+  console.log(res.headers)
+  const body = getStream(res.stream)
+  console.log(body)
+}
+
+streaming()

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "example": "node examples/example.js",
+    "example:localhost": "node examples/example.localhost.js",
     "test": "standard | snazzy && tap test/*.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
   },
   "homepage": "https://github.com/mcollina/h2url#readme",
   "devDependencies": {
-    "assert": "^1.4.1",
-    "await-to-ts": "^1.0.6",
     "pre-commit": "^1.2.2",
     "snazzy": "^7.0.0",
     "standard": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "h2url": "h2url.js"
   },
   "scripts": {
+    "example": "node examples/example.js",
     "test": "standard | snazzy && tap test/*.js"
   },
   "repository": {
@@ -24,6 +25,8 @@
   },
   "homepage": "https://github.com/mcollina/h2url#readme",
   "devDependencies": {
+    "assert": "^1.4.1",
+    "await-to-ts": "^1.0.6",
     "pre-commit": "^1.2.2",
     "snazzy": "^7.0.0",
     "standard": "^10.0.3",


### PR DESCRIPTION
fixes #5 

**NOTE**: this is not fixing the `Invalid URL` error, i.e.

```
╭─phra at kali in /home/phra/git/h2url (master ✚1…2)
╰─λ node example.js                                                                                                                                             0 < 00:04:13
(node:13761) ExperimentalWarning: The http2 module is an experimental API.
{ TypeError [ERR_INVALID_URL]: Invalid URL: undefined
    at onParseError (internal/url.js:219:17)
    at parse (internal/url.js:228:3)
    at new URL (internal/url.js:311:5)
    at Object.request (/home/phra/git/h2url/index.js:13:15)
    at streaming (/home/phra/git/h2url/example.js:18:37)
    at Object.<anonymous> (/home/phra/git/h2url/example.js:32:1)
    at Module._compile (module.js:612:30)
    at Object.Module._extensions..js (module.js:623:10)
    at Module.load (module.js:531:32)
    at tryModuleLoad (module.js:494:12) input: 'undefined' }
```